### PR TITLE
@orta: Fixes header link

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,7 +2,7 @@
 
   <div class="wrapper">
 
-    <a class="site-title" href="{{ site.baseurl }}/">{{ site.title }}</a>
+    <a class="site-title" href="{{ site.baseurl }}">{{ site.title }}</a>
 
     <nav class="site-nav">
       <a href="#" class="menu-icon">


### PR DESCRIPTION
The `baseurl` is already "/mobile/", so we had a href as "http://artsy.github.io/mobile//"